### PR TITLE
fix: allow hyphen and unicode characters in JSPMemberNameSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Remove dependency on `protolude`
 - Fix parsing bug with Wildcard Selector
 - Implement Descendant Segment
+- Fix allowed characters in the `member-name-shorthand`
 
 ## 0.1.0.0
 

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -12,6 +12,7 @@ import Data.Aeson.JSONPath.Parser (pJSPQuery
                                   , JSPDescSegment (..)
                                   , JSPSelector (..)
                                   , JSPWildcardT (..))
+import Data.Either                (isLeft)
 import Prelude
 
 spec :: Spec
@@ -55,3 +56,12 @@ spec = do
 
     it "parses query: $..[*]" $
       P.parse pJSPQuery "" "$..[*]" `shouldBe` Right (JSPRoot [JSPDescSeg (JSPDescBracketed [JSPWildSel JSPWildcard])])
+
+    it "parses query $.hyphen-key" $
+      P.parse pJSPQuery "" "$.hyphen-key" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "hyphen-key")])
+
+    it "fails with $.1startsWithNum" $
+      P.parse pJSPQuery "" "$.1startsWithNum" `shouldSatisfy` isLeft
+
+    it "parses query $.©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ" $
+      P.parse pJSPQuery "" "$.©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ")])


### PR DESCRIPTION
Allow hyphen and unicode characters to member-name-shorthand.