### PR TITLE
feat: allow spaces around JSONPath query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Allow spaces around the JSONPath query
+
 ## 0.2.0.0
 
 - Remove dependency on `protolude`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aeson-jsonpath
 
-![ci-badge](https://github.com/taimoorzaeem/aeson-jsonpath/actions/workflows/build.yml/badge.svg?event=push) ![hackage-docs](https://img.shields.io/badge/hackage-v0.1.0.0-blue)
+![ci-badge](https://github.com/taimoorzaeem/aeson-jsonpath/actions/workflows/build.yml/badge.svg?event=push) [![hackage-docs](https://img.shields.io/badge/hackage-v0.2.0.0-blue)](https://hackage.haskell.org/package/aeson-jsonpath)
 
 Run [RFC 9535](https://www.rfc-editor.org/rfc/rfc9535) compliant JSONPath queries on [Data.Aeson](https://hackage.haskell.org/package/aeson).
 

--- a/src/Data/Aeson/JSONPath/Parser.hs
+++ b/src/Data/Aeson/JSONPath/Parser.hs
@@ -66,8 +66,10 @@ type JSPSliceSelector = (Maybe Int, Maybe Int, Int)
 
 pJSPQuery :: P.Parser JSPQuery
 pJSPQuery = do
+  P.spaces
   P.char '$'
   segs <- P.many pJSPSegment
+  P.spaces
   P.eof
   return $ JSPRoot segs
 
@@ -124,7 +126,7 @@ pJSPChildMemberNameSH :: P.Parser JSPChildSegment
 pJSPChildMemberNameSH = do
   P.char '.'
   P.lookAhead (P.letter <|> P.oneOf "-" <|> pUnicodeChar)
-  val <- T.pack <$> P.many1 (P.alphaNum <|> (P.oneOf "-" <|> pUnicodeChar))
+  val <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "-" <|> pUnicodeChar)
   return (JSPChildMemberNameSH val)
 
 pJSPChildWildSeg :: P.Parser JSPChildSegment

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -65,3 +65,6 @@ spec = do
 
     it "parses query $.©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ" $
       P.parse pJSPQuery "" "$.©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "©®±×÷Ωπ•€→∀∃∈≠≤≥✓λ")])
+
+    it "parses query with spaces around" $
+      P.parse pJSPQuery "" "  $.key  " `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "key")])

--- a/test/QuerySpec.hs
+++ b/test/QuerySpec.hs
@@ -260,9 +260,9 @@ spec = do
     it "returns root with query $[*]" $
       runJSPQuery [jsonPath|$[*]|] rootDoc `shouldBe` (toSingletonArray rootDoc)
 
-    it "returns root with query $..*" $
+    it "returns descendants with query $..*" $
       runJSPQuery [jsonPath|$..*|] rfcExample1 `shouldBe` rfcExample1Desc
 
-    it "returns root with query $..[*]" $ do
+    it "returns descendants with query $..[*]" $ do
       pendingWith "fix with wildcard selection"
       runJSPQuery [jsonPath|$..[*]|] rfcExample1 `shouldBe` rfcExample1Desc


### PR DESCRIPTION
Allow spaces around `JSONPath` query.