### PR TITLE
feat: always return (Vector Value) and rename runJSPQuery to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Allow spaces around the JSONPath query
+- Always return `Vector Value` and rename `runJSPQuery` to `query`
 
 ## 0.2.0.0
 


### PR DESCRIPTION
Always return `Vector Value` and rename `runJSPQuery` to `query`