### PR TITLE
fix: replace hyphen with underscore in member-name-shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Allow spaces around the JSONPath query
 - Always return `Vector Value` and rename `runJSPQuery` to `query`
+- Replace hyphen with underscore in `member-name-shorthand`
 
 ## 0.2.0.0
 

--- a/src/Data/Aeson/JSONPath/Parser.hs
+++ b/src/Data/Aeson/JSONPath/Parser.hs
@@ -100,8 +100,8 @@ pJSPChildBracketed =  do
 pJSPChildMemberNameSH :: P.Parser JSPChildSegment
 pJSPChildMemberNameSH = do
   P.char '.'
-  P.lookAhead (P.letter <|> P.oneOf "-" <|> pUnicodeChar)
-  val <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "-" <|> pUnicodeChar)
+  P.lookAhead (P.letter <|> P.oneOf "_" <|> pUnicodeChar)
+  val <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "_" <|> pUnicodeChar)
   return (JSPChildMemberNameSH val)
 
 pJSPChildWildSeg :: P.Parser JSPChildSegment
@@ -129,8 +129,8 @@ pJSPDescBracketed =  do
 pJSPDescMemberNameSH :: P.Parser JSPDescSegment
 pJSPDescMemberNameSH = do
   P.string ".."
-  P.lookAhead (P.letter <|> P.oneOf "-" <|> pUnicodeChar)
-  val <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "-" <|> pUnicodeChar)
+  P.lookAhead (P.letter <|> P.oneOf "_" <|> pUnicodeChar)
+  val <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "_" <|> pUnicodeChar)
   return (JSPDescMemberNameSH val)
 
 pJSPDescWildSeg :: P.Parser JSPDescSegment
@@ -248,8 +248,8 @@ pJSPSingleQNameSeg = P.try pSingleQNameBracketed <|> P.try pSingleQNameDotted
 
     pSingleQNameDotted = do
       P.char '.'
-      P.lookAhead (P.letter <|> P.oneOf "-" <|> pUnicodeChar)
-      name <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "-" <|> pUnicodeChar)
+      P.lookAhead (P.letter <|> P.oneOf "_" <|> pUnicodeChar)
+      name <- T.pack <$> P.many1 (P.alphaNum <|> P.oneOf "_" <|> pUnicodeChar)
       return $ JSPSingleQNameSeg name
 
 pJSPSingleQIndexSeg :: P.Parser JSPSingleQSegment

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -71,9 +71,6 @@ spec = do
     it "parses query: $..[*]" $
       P.parse pJSPQuery "" "$..[*]" `shouldBe` Right (JSPRoot [JSPDescSeg (JSPDescBracketed [JSPWildSel JSPWildcard])])
 
-    it "parses query $.hyphen-key" $
-      P.parse pJSPQuery "" "$.hyphen-key" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "hyphen-key")])
-
     it "fails with $.1startsWithNum" $
       P.parse pJSPQuery "" "$.1startsWithNum" `shouldSatisfy` isLeft
 
@@ -82,6 +79,12 @@ spec = do
 
     it "parses query with spaces around" $
       P.parse pJSPQuery "" "  $.key  " `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "key")])
+
+    it "parses query: $._" $
+      P.parse pJSPQuery "" "$._" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "_")])
+
+    it "parses query: $.underscore_key" $
+      P.parse pJSPQuery "" "$.underscore_key" `shouldBe` Right (JSPRoot [JSPChildSeg (JSPChildMemberNameSH "underscore_key")])
 
     describe "parses JSPFilter Query" $ do
       it "$..books[?@.category == 'reference'].*" $


### PR DESCRIPTION
Replace hyphen with underscore in `member-name-shorthand`.