### PR TITLE
fix: fix comparison expression in filter selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this package are documented in this file. This project ad
 
 ## Unreleased
 
-- Allow spaces around the JSONPath query
-- Always return `Vector Value` and rename `runJSPQuery` to `query`
-- Replace hyphen with underscore in `member-name-shorthand`
+- Always return `Vector Value`
 - Implement Filter Selector
+- Introduce JSONPath Standard Compliance Testing, See: [test-suite](https://github.com/jsonpath-standard/jsonpath-compliance-test-suite)
 
 ## 0.2.0.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-23.1
+resolver: lts-23.3
 
 packages:
 - .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 18514ff1ed00330c922bd8d28d88a54670a9849f17eb07dc78391a94d576749d
-    size: 678854
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/1.yaml
-  original: lts-23.1
+    sha256: dd89d2322cb5af74c6ab9d96c0c5f6c8e6653e0c991d619b4bb141a49cb98668
+    size: 679282
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/3.yaml
+  original: lts-23.3

--- a/test/ComplianceSpec.hs
+++ b/test/ComplianceSpec.hs
@@ -58,6 +58,7 @@ spec TestSuite{tests} = do
   describe "Run Compliance Tests" $ do
     mapM_ runTestCase tests
 
+
 runTestCase :: TestCase -> SpecWith ()
 -- skip function extension tests
 runTestCase tc@TestCase{tags=Just xs, ..} =
@@ -68,17 +69,17 @@ runTestCase tc@TestCase{tags=Just xs, ..} =
 
 -- invalid selector should not parse correctly
 runTestCase TestCase{invalidSel=(Just True), ..} =
-  xit (name ++ ": " ++ selector) $
+  it name $
     P.parse pQuery "" selector `shouldSatisfy` isLeft
 
 -- if result is deterministic (one json)
 runTestCase TestCase{result=(Just r), document=(Just doc), ..} =
-  xit (name ++ ": " ++ selector) $
+  it name $
     query selector doc `shouldBe` Right r
 
 -- if result is non-deterministic (any json from the list of results)
 runTestCase TestCase{results=(Just rs), document=(Just doc), ..} = do
-  xit (name ++ ": " ++ selector) $
+  it name $
     query selector doc `shouldSatisfy` (\x -> elem (fromRight V.empty x) rs)
 
 runTestCase _ = pure ()


### PR DESCRIPTION
All compliance tests introduced in #22 are now passing, with the exception of tests related to function extensions which are not yet implemented.