### PR TITLE
test: add jsonpath-compliance-test-suite as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jsonpath-compliance-test-suite"]
+	path = jsonpath-compliance-test-suite
+	url = https://github.com/jsonpath-standard/jsonpath-compliance-test-suite.git


### PR DESCRIPTION
The plan is to add nightly CI testing against the test suite.