### PR TITLE
refactor: separate Literal from Comparable

### DIFF
--- a/src/Data/Aeson/JSONPath/Parser/Filter.hs
+++ b/src/Data/Aeson/JSONPath/Parser/Filter.hs
@@ -94,26 +94,29 @@ pComparisonOp = P.try (P.string ">=" $> GreaterOrEqual)
              <|> P.try (P.string "==" $> Equal)
 
 pComparable :: P.Parser Comparable
-pComparable = P.try pCompLitString
-              <|> P.try pCompLitNum
-              <|> P.try pCompLitBool
-              <|> P.try pCompLitNull
-              <|> P.try pCompSQ
+pComparable = P.try pCompLit <|> P.try pCompSQ
 
-pCompLitString :: P.Parser Comparable
-pCompLitString = CompLitString . T.pack <$> (P.try pSingleQuotted <|> P.try pDoubleQuotted)
+pCompLit :: P.Parser Comparable
+pCompLit = CompLit
+            <$> (P.try pLitString
+            <|> P.try pLitNum
+            <|> P.try pLitBool
+            <|> P.try pLitNull)
 
-pCompLitNum :: P.Parser Comparable
-pCompLitNum = CompLitNum 
+pLitString :: P.Parser Literal
+pLitString = LitString . T.pack <$> (P.try pSingleQuotted <|> P.try pDoubleQuotted)
+
+pLitNum :: P.Parser Literal
+pLitNum = LitNum 
            <$> (P.try (P.string "-0" $> (0 :: Scientific)) -- edge case
            <|> P.try pDoubleScientific 
            <|> P.try pScientific)
 
-pCompLitBool :: P.Parser Comparable
-pCompLitBool = CompLitBool <$> (P.try (P.string "true" $> True) <|> P.try (P.string "false" $> False))
+pLitBool :: P.Parser Literal
+pLitBool = LitBool <$> (P.try (P.string "true" $> True) <|> P.try (P.string "false" $> False))
 
-pCompLitNull :: P.Parser Comparable
-pCompLitNull = P.string "null" $> CompLitNull
+pLitNull :: P.Parser Literal
+pLitNull = P.string "null" $> LitNull
 
 pCompSQ :: P.Parser Comparable
 pCompSQ = CompSQ <$> (P.try pCurrentSingleQ <|> P.try pRootSingleQ)

--- a/src/Data/Aeson/JSONPath/Query/Filter.hs
+++ b/src/Data/Aeson/JSONPath/Query/Filter.hs
@@ -79,10 +79,13 @@ compareVals NotEqual       o1 o2 = o1 /= o2
 
 
 getComparableVal :: Comparable -> QueryState -> Maybe Value
-getComparableVal (CompLitNum num) _ = Just $ JSON.Number num
-getComparableVal (CompLitString txt) _ = Just $ JSON.String txt
-getComparableVal (CompLitBool bool) _ = Just $ JSON.Bool bool
-getComparableVal CompLitNull _ = Just JSON.Null
+getComparableVal (CompLit lit) _ = 
+  case lit of
+    LitString txt -> Just $ JSON.String txt
+    LitNum num    -> Just $ JSON.Number num
+    LitBool bool  -> Just $ JSON.Bool bool
+    LitNull       -> Just JSON.Null
+
 getComparableVal (CompSQ SingularQuery{..}) QueryState{..} = case singularQueryType of
   RootSQ -> traverseSingularQSegs (Just rootVal) singularQuerySegments
   CurrentSQ -> traverseSingularQSegs (Just curVal) singularQuerySegments

--- a/src/Data/Aeson/JSONPath/Types/Filter.hs
+++ b/src/Data/Aeson/JSONPath/Types/Filter.hs
@@ -15,6 +15,7 @@ module Data.Aeson.JSONPath.Types.Filter
   , ComparisonExpr (..)
   , ComparisonOp (..)
   , Comparable (..)
+  , Literal (..)
   , SingularQueryType (..)
   , SingularQuery (..)
   , SingularQuerySegment (..)
@@ -64,11 +65,16 @@ data ComparisonOp
 
 -- |
 data Comparable
-  = CompLitString Text
-  | CompLitNum Scientific
-  | CompLitBool Bool
-  | CompLitNull
+  = CompLit Literal
   | CompSQ SingularQuery
+  deriving (Eq, Show, Lift)
+
+-- |
+data Literal
+  = LitString Text
+  | LitNum Scientific
+  | LitBool Bool
+  | LitNull
   deriving (Eq, Show, Lift)
 
 -- |

--- a/test/spec/ParserSpec.hs
+++ b/test/spec/ParserSpec.hs
@@ -261,7 +261,7 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "category"]
-            }) Equal (CompLitString "reference"))]])]
+            }) Equal (CompLit (LitString "reference")))]])]
           }]
         }
 
@@ -298,10 +298,10 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Less (CompLitNum 20.0)), Comparison (Comp (CompSQ SingularQuery {
+            }) Less (CompLit (LitNum 20.0))), Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Greater (CompLitNum 10.0))]])]
+            }) Greater (CompLit (LitNum 10.0)))]])]
           }]
         }
 
@@ -315,10 +315,10 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Less (CompLitNum 20.0))], LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
+            }) Less (CompLit (LitNum 20.0)))], LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Greater (CompLitNum 10.0))]])]
+            }) Greater (CompLit (LitNum 10.0)))]])]
           }]
         }
 
@@ -355,10 +355,10 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [NotParen (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            })  Less (CompLitNum 20.0)), Comparison (Comp (CompSQ SingularQuery {
+            })  Less (CompLit (LitNum 20.0))), Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Greater (CompLitNum 10.0))]])]])]
+            }) Greater (CompLit (LitNum 10.0)))]])]])]
           }]
         }
 
@@ -378,7 +378,7 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Less (CompLitNum (-1.0e20)))]])]
+            }) Less (CompLit (LitNum (-1.0e20))))]])]
           }]
         }
 
@@ -398,7 +398,7 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "price"]
-            }) Less (CompLitNum (1.0e-2)))]])]
+            }) Less (CompLit (LitNum (1.0e-2))))]])]
           }]
         }
 
@@ -418,7 +418,7 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "is_available"]
-            }) Equal (CompLitBool True))]])]
+            }) Equal (CompLit (LitBool True)))]])]
           }]
         }
 
@@ -438,6 +438,6 @@ spec = do
             segment = Bracketed [Filter (LogicalOr [LogicalAnd [Comparison (Comp (CompSQ SingularQuery {
               singularQueryType = CurrentSQ,
               singularQuerySegments = [NameSQSeg "is_available"]
-            }) Equal CompLitNull)]])]
+            }) Equal (CompLit LitNull))]])]
           }]
         }


### PR DESCRIPTION
This refactor will later allow us to implement function extension in much more cleaner way