### PR TITLE
fix: allow spaces in relative query and singular query segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this package are documented in this file. This project adheres to [Haskell PVP](https://pvp.haskell.org/) versioning.
 
+## Unreleased
+
+- #43, Fix spaces not allowed in relative query and singular query segments
+
 ## 0.3.0.1
 
 - #31, Fix `test/cts.json` not included in hackage bundle

--- a/src/Data/Aeson/JSONPath/Parser/Filter.hs
+++ b/src/Data/Aeson/JSONPath/Parser/Filter.hs
@@ -124,13 +124,13 @@ pCompSQ = CompSQ <$> (P.try pCurrentSingleQ <|> P.try pRootSingleQ)
 pCurrentSingleQ :: P.Parser SingularQuery
 pCurrentSingleQ = do
   P.char '@'
-  segs <- P.many pSingularQuerySegment
+  segs <- P.many $ P.try (pSpaces *> pSingularQuerySegment)
   return $ SingularQuery { singularQueryType = CurrentSQ, singularQuerySegments = segs }
 
 pRootSingleQ :: P.Parser SingularQuery
 pRootSingleQ = do
   P.char '$'
-  segs <- P.many pSingularQuerySegment
+  segs <- P.many $ P.try (pSpaces *> pSingularQuerySegment)
   return $ SingularQuery { singularQueryType = RootSQ, singularQuerySegments = segs }
 
 pSingularQuerySegment :: P.Parser SingularQuerySegment

--- a/src/Data/Aeson/JSONPath/Parser/Query.hs
+++ b/src/Data/Aeson/JSONPath/Parser/Query.hs
@@ -31,14 +31,20 @@ import Prelude
 pRootQuery :: P.Parser Query
 pRootQuery = do
   P.char '$'
-  segs <- P.many (pSpaces *> pQuerySegment (P.try pRootQuery <|> P.try pCurrentQuery))
+  segs <- P.many $ P.try pSpacedOutSegments
   return $ Query { queryType = Root, querySegments = segs }
+    where
+      pQ = P.try pRootQuery <|> P.try pCurrentQuery
+      pSpacedOutSegments = pSpaces *> pQuerySegment pQ
 
 pCurrentQuery :: P.Parser Query
 pCurrentQuery = do
   P.char '@'
-  segs <- P.many $ pQuerySegment (P.try pRootQuery <|> P.try pCurrentQuery)
+  segs <- P.many $ P.try pSpacedOutSegments
   return $ Query { queryType = Current, querySegments = segs }
+    where
+      pQ = P.try pRootQuery <|> P.try pCurrentQuery
+      pSpacedOutSegments = pSpaces *> pQuerySegment pQ
 
 
 pQuerySegment :: P.Parser a -> P.Parser (QuerySegment a)

--- a/test/spec/QuerySpec.hs
+++ b/test/spec/QuerySpec.hs
@@ -339,6 +339,10 @@ spec = do
       queryQQ [jsonPath|$.store.books[?@.author]|] rootDoc
       `shouldBe` getVector booksDoc
 
+    it "returns with filtering with spaced out segments: test expression" $
+      queryQQ [jsonPath|$  .store  .books[?@  .author]|] rootDoc
+      `shouldBe` getVector booksDoc
+
     it "returns with filtering: test expr gives empty with non-existent key" $
       queryQQ [jsonPath|$.store.books[?@.not_here]|] rootDoc
       `shouldBe` V.empty


### PR DESCRIPTION
Allow spaces in relative query and singular query segments.